### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,20 @@ Semantic versioning tool for git based on conventional commits.
 Prebuilt multi-arch binaries are available for Linux and macOS.
 
 ```Shell
-# linux amd64
+# Linux amd64
 curl -SsfL https://github.com/thegeeklab/git-sv/releases/latest/download/git-sv-linux-amd64 -o ~/.local/bin/git-sv
-chmod +x /usr/local/bin/git-sv
+chmod +x ~/.local/bin/git-sv
 ```
 
 ```Shell
-# macOS
+# macOS arm
 curl -SsfL https://github.com/thegeeklab/git-sv/releases/latest/download/git-sv-darwin-10.12-arm64 -o ~/.local/bin/git-sv
+chmod +x ~/.local/bin/git-sv
+```
+
+```Shell
+# macOS intel
+curl -SsfL https://github.com/thegeeklab/git-sv/releases/latest/download/git-sv-darwin-10.12-amd64 -o ~/.local/bin/git-sv
 chmod +x ~/.local/bin/git-sv
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ Prebuilt multi-arch binaries are available for Linux and macOS.
 
 ```Shell
 # linux amd64
-curl -SsfL https://github.com/thegeeklab/git-sv/releases/latest/download/git-sv-linux-amd64 -o ~/.local/bin/git-sv && chmod +x /usr/local/bin/git-sv
+curl -SsfL https://github.com/thegeeklab/git-sv/releases/latest/download/git-sv-linux-amd64 -o ~/.local/bin/git-sv
+chmod +x /usr/local/bin/git-sv
+```
 
+```Shell
 # macOS
-curl -SsfL https://github.com/thegeeklab/git-sv/releases/latest/download/git-sv-darwin-10.12-arm64 -o ~/.local/bin/git-sv && chmod +x ~/.local/bin/git-sv
+curl -SsfL https://github.com/thegeeklab/git-sv/releases/latest/download/git-sv-darwin-10.12-arm64 -o ~/.local/bin/git-sv
+chmod +x ~/.local/bin/git-sv
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Semantic versioning tool for git based on conventional commits.
 Prebuilt multi-arch binaries are available for Linux and macOS.
 
 ```Shell
-curl -SsfL https://github.com/thegeeklab/git-sv/releases/latest/download/git-sv-linux-amd64 -o /usr/local/bin/git-sv
-chmod +x /usr/local/bin/git-sv
+# linux amd64
+curl -SsfL https://github.com/thegeeklab/git-sv/releases/latest/download/git-sv-linux-amd64 -o ~/.local/bin/git-sv && chmod +x /usr/local/bin/git-sv
+
+# macOS
+curl -SsfL https://github.com/thegeeklab/git-sv/releases/latest/download/git-sv-darwin-10.12-arm64 -o ~/.local/bin/git-sv && chmod +x ~/.local/bin/git-sv
 ```
 
 ## Build


### PR DESCRIPTION
- Use one-liner
- Use `~/.local/bin` instead of `/usr/local/bin` as the latter is not writable by rootless users

Not sure if the macOS version part is really needed. If not, this could save some work updating the identifier in the README.

Maybe two code blocks might make things easier, i.e. have easy c/p.