### PR TITLE
fix: avoid invalid semver versions

### DIFF
--- a/sv/commit.go
+++ b/sv/commit.go
@@ -88,6 +88,10 @@ func (p SemVerCommitProcessor) NextVersion(
 
 	newVersion := updateVersion(*version, versionToUpdate)
 
+	if newVersion.Major() == 0 && newVersion.Minor() == 0 {
+		newVersion = updateVersion(*version, minor)
+	}
+
 	return &newVersion, updated
 }
 

--- a/sv/commit_test.go
+++ b/sv/commit_test.go
@@ -21,7 +21,7 @@ func TestSemVerCommitProcessor_NextVersion(t *testing.T) {
 			true,
 			TestVersion("0.0.0"),
 			[]CommitLog{},
-			TestVersion("0.0.0"),
+			TestVersion("0.1.0"),
 			false,
 		},
 		{
@@ -37,7 +37,7 @@ func TestSemVerCommitProcessor_NextVersion(t *testing.T) {
 			true,
 			TestVersion("0.0.0"),
 			[]CommitLog{TestCommitlog("a", map[string]string{}, "a")},
-			TestVersion("0.0.0"),
+			TestVersion("0.1.0"),
 			false,
 		},
 		{
@@ -45,7 +45,7 @@ func TestSemVerCommitProcessor_NextVersion(t *testing.T) {
 			false,
 			TestVersion("0.0.0"),
 			[]CommitLog{TestCommitlog("none", map[string]string{}, "a")},
-			TestVersion("0.0.0"),
+			TestVersion("0.1.0"),
 			false,
 		},
 		{
@@ -53,14 +53,14 @@ func TestSemVerCommitProcessor_NextVersion(t *testing.T) {
 			false,
 			TestVersion("0.0.0"),
 			[]CommitLog{TestCommitlog("a", map[string]string{}, "a")},
-			TestVersion("0.0.1"),
+			TestVersion("0.1.0"),
 			true,
 		},
 		{
 			"patch update",
 			false, TestVersion("0.0.0"),
 			[]CommitLog{TestCommitlog("patch", map[string]string{}, "a")},
-			TestVersion("0.0.1"), true,
+			TestVersion("0.1.0"), true,
 		},
 		{
 			"patch update without version",


### PR DESCRIPTION
Avoid invalid versions like `0.0.1`.