### PR TITLE
feat: add `retag` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ COMMANDS:
    release-notes, rn             generate release notes
    changelog, cgl                generate changelog
    tag, tg                       generate tag with version based on git commit messages
+   retag, rt                     move the most recent (or a specific) tag to HEAD and force-push it
    commit, cmt                   execute git commit with conventional commit message helper
    validate-commit-message, vcm  use as prepare-commit-message hook to validate and enhance commit message
    help, h                       Shows a list of commands or help for one command

--- a/app/app.go
+++ b/app/app.go
@@ -25,8 +25,9 @@ var (
 
 // Tag git tag info.
 type Tag struct {
-	Name string
-	Date time.Time
+	Name      string
+	Date      time.Time
+	Annotated bool
 }
 
 // LogRangeType type of log range.
@@ -344,7 +345,9 @@ func (g GitSV) Tags() ([]Tag, error) {
 
 		// Try to get annotated tag first
 		tagObj, err := repo.TagObject(ref.Hash())
-		if err == nil {
+
+		annotated := err == nil
+		if annotated {
 			tagDate = tagObj.Tagger.When
 		} else {
 			// For lightweight tags, get the commit
@@ -356,8 +359,9 @@ func (g GitSV) Tags() ([]Tag, error) {
 		}
 
 		tags = append(tags, Tag{
-			Name: tagName,
-			Date: tagDate,
+			Name:      tagName,
+			Date:      tagDate,
+			Annotated: annotated,
 		})
 
 		return nil

--- a/app/commands/retag.go
+++ b/app/commands/retag.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/thegeeklab/git-sv/app"
+	"github.com/thegeeklab/git-sv/sv"
+	"github.com/urfave/cli/v3"
+)
+
+var errNoTagToRetag = errors.New("no tag found to retag")
+
+func RetagFlags(settings *app.RetagSettings) []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "annotate",
+			Aliases:     []string{"a"},
+			Usage:       "make an annotated tag object",
+			Destination: &settings.Annotate,
+		},
+		&cli.BoolFlag{
+			Name:        "local",
+			Usage:       "retag local tag only",
+			Destination: &settings.Local,
+		},
+		&cli.StringFlag{
+			Name:        "tag",
+			Aliases:     []string{"t"},
+			Usage:       "retag a specific tag instead of the most recent one",
+			Destination: &settings.Tag,
+		},
+	}
+}
+
+func RetagHandler(g app.GitSV, settings *app.RetagSettings) cli.ActionFunc {
+	return func(_ context.Context, _ *cli.Command) error {
+		target := settings.Tag
+		if target == "" {
+			target = g.LastTag()
+		}
+
+		if target == "" {
+			return errNoTagToRetag
+		}
+
+		version, err := sv.ToVersion(target)
+		if err != nil {
+			return fmt.Errorf("error parsing version: %s from git tag: %w", target, err)
+		}
+
+		tagname, err := g.Tag(*version, settings.Annotate, settings.Local, true)
+		if err != nil {
+			return fmt.Errorf("error retagging version: %s: %w", version.String(), err)
+		}
+
+		fmt.Println(tagname)
+
+		return nil
+	}
+}

--- a/app/commands/retag.go
+++ b/app/commands/retag.go
@@ -4,20 +4,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/thegeeklab/git-sv/app"
 	"github.com/thegeeklab/git-sv/sv"
 	"github.com/urfave/cli/v3"
 )
 
-var errNoTagToRetag = errors.New("no tag found to retag")
+var (
+	errNoTagToRetag = errors.New("no tag found to retag")
+	errTagNotFound  = errors.New("tag not found")
+)
 
 func RetagFlags(settings *app.RetagSettings) []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{
 			Name:        "annotate",
 			Aliases:     []string{"a"},
-			Usage:       "make an annotated tag object",
+			Usage:       "force an annotated tag object (annotated source tags are preserved regardless)",
 			Destination: &settings.Annotate,
 		},
 		&cli.BoolFlag{
@@ -28,7 +32,7 @@ func RetagFlags(settings *app.RetagSettings) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "tag",
 			Aliases:     []string{"t"},
-			Usage:       "retag a specific tag instead of the most recent one",
+			Usage:       "retag a specific existing tag instead of the most recently created one",
 			Destination: &settings.Tag,
 		},
 	}
@@ -36,21 +40,40 @@ func RetagFlags(settings *app.RetagSettings) []cli.Flag {
 
 func RetagHandler(g app.GitSV, settings *app.RetagSettings) cli.ActionFunc {
 	return func(_ context.Context, _ *cli.Command) error {
-		target := settings.Tag
-		if target == "" {
-			target = g.LastTag()
-		}
-
-		if target == "" {
-			return errNoTagToRetag
-		}
-
-		version, err := sv.ToVersion(target)
+		tags, err := g.Tags()
 		if err != nil {
-			return fmt.Errorf("error parsing version: %s from git tag: %w", target, err)
+			return fmt.Errorf("error listing tags: %w", err)
 		}
 
-		tagname, err := g.Tag(*version, settings.Annotate, settings.Local, true)
+		var target app.Tag
+
+		if settings.Tag != "" {
+			idx := slices.IndexFunc(tags, func(t app.Tag) bool { return t.Name == settings.Tag })
+			if idx < 0 {
+				return fmt.Errorf("%w: %s", errTagNotFound, settings.Tag)
+			}
+
+			target = tags[idx]
+		} else {
+			if len(tags) == 0 {
+				return errNoTagToRetag
+			}
+
+			// Tags() is sorted by date (oldest first), so the most recently
+			// created tag is the last entry.
+			target = tags[len(tags)-1]
+		}
+
+		version, err := sv.ToVersion(target.Name)
+		if err != nil {
+			return fmt.Errorf("error parsing version: %s from git tag: %w", target.Name, err)
+		}
+
+		// Preserve the original tag type: never silently downgrade an annotated
+		// tag to a lightweight one.
+		annotate := settings.Annotate || target.Annotated
+
+		tagname, err := g.Tag(*version, annotate, settings.Local, true)
 		if err != nil {
 			return fmt.Errorf("error retagging version: %s: %w", version.String(), err)
 		}

--- a/app/commands/retag_test.go
+++ b/app/commands/retag_test.go
@@ -1,0 +1,20 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thegeeklab/git-sv/app"
+)
+
+func TestRetagFlags(t *testing.T) {
+	flags := RetagFlags(&app.RetagSettings{})
+	assert.NotEmpty(t, flags)
+}
+
+func TestRetagHandler(t *testing.T) {
+	gsv := app.New()
+	settings := &app.RetagSettings{}
+	handler := RetagHandler(gsv, settings)
+	assert.NotNil(t, handler)
+}

--- a/app/commands/retag_test.go
+++ b/app/commands/retag_test.go
@@ -1,11 +1,74 @@
 package commands
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thegeeklab/git-sv/app"
 )
+
+// runGit runs a git command inside the current working directory and returns
+// its trimmed combined output.
+func runGit(t *testing.T, env []string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	if env != nil {
+		cmd.Env = append(os.Environ(), env...)
+	}
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+// setupRetagRepo initializes an empty git repository in a temp dir, chdirs into
+// it and returns the path.
+func setupRetagRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	runGit(t, nil, "init", "-b", "main")
+	runGit(t, nil, "config", "user.email", "test@example.com")
+	runGit(t, nil, "config", "user.name", "Test User")
+	runGit(t, nil, "config", "commit.gpgsign", "false")
+	runGit(t, nil, "config", "tag.gpgSign", "false")
+
+	return dir
+}
+
+// commit creates a file, commits it with a fixed author/committer date and
+// returns the resulting commit hash.
+func commit(t *testing.T, dir, name, date string) string {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(name), 0o644))
+	runGit(t, nil, "add", ".")
+
+	env := []string{"GIT_AUTHOR_DATE=" + date, "GIT_COMMITTER_DATE=" + date}
+	runGit(t, env, "commit", "-m", "chore: add "+name)
+
+	return runGit(t, nil, "rev-parse", "HEAD")
+}
+
+func runRetag(t *testing.T, settings *app.RetagSettings) error {
+	t.Helper()
+
+	gsv := app.New()
+
+	return RetagHandler(gsv, settings)(context.Background(), nil)
+}
 
 func TestRetagFlags(t *testing.T) {
 	flags := RetagFlags(&app.RetagSettings{})
@@ -17,4 +80,66 @@ func TestRetagHandler(t *testing.T) {
 	settings := &app.RetagSettings{}
 	handler := RetagHandler(gsv, settings)
 	assert.NotNil(t, handler)
+}
+
+func TestRetagHandlerNoTags(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+
+	err := runRetag(t, &app.RetagSettings{Local: true})
+	assert.ErrorIs(t, err, errNoTagToRetag)
+}
+
+func TestRetagHandlerSpecificTagNotFound(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "1.0.0")
+
+	err := runRetag(t, &app.RetagSettings{Local: true, Tag: "9.9.9"})
+
+	// A specific tag that does not exist must fail instead of silently
+	// creating a fresh tag at HEAD.
+	assert.ErrorIs(t, err, errTagNotFound)
+
+	tags := runGit(t, nil, "tag", "--list")
+	assert.NotContains(t, tags, "9.9.9")
+}
+
+func TestRetagHandlerMostRecentByDate(t *testing.T) {
+	dir := setupRetagRepo(t)
+
+	// Highest semver tag is created on the oldest commit, while a lower version
+	// is tagged more recently (e.g. a backport).
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "2.0.0")
+
+	commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+	runGit(t, nil, "tag", "1.5.0")
+
+	head := commit(t, dir, "c.txt", "2022-01-01T00:00:00")
+
+	err := runRetag(t, &app.RetagSettings{Local: true})
+	require.NoError(t, err)
+
+	// The chronologically newest tag (1.5.0) is moved to HEAD, the higher
+	// semver tag (2.0.0) is left untouched.
+	assert.Equal(t, head, runGit(t, nil, "rev-parse", "1.5.0"))
+	assert.NotEqual(t, head, runGit(t, nil, "rev-parse", "2.0.0"))
+}
+
+func TestRetagHandlerPreservesAnnotatedType(t *testing.T) {
+	dir := setupRetagRepo(t)
+
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+
+	env := []string{"GIT_COMMITTER_DATE=2020-01-01T00:00:00", "GIT_AUTHOR_DATE=2020-01-01T00:00:00"}
+	runGit(t, env, "tag", "-a", "-m", "release 1.0.0", "1.0.0")
+
+	commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+
+	// Retag without -a must not downgrade the annotated tag to a lightweight one.
+	err := runRetag(t, &app.RetagSettings{Local: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, "tag", runGit(t, nil, "cat-file", "-t", "1.0.0"))
 }

--- a/app/config.go
+++ b/app/config.go
@@ -20,6 +20,7 @@ type Settings struct {
 	CommitNotesSettings  CommitNotesSettings
 	CommitLogSettings    CommitLogSettings
 	TagSettings          TagSettings
+	RetagSettings        RetagSettings
 }
 
 type ChangelogSettings struct {
@@ -53,6 +54,12 @@ type TagSettings struct {
 	Annotate bool
 	Local    bool
 	Force    bool
+}
+
+type RetagSettings struct {
+	Annotate bool
+	Local    bool
+	Tag      string
 }
 
 // Config cli yaml config.

--- a/cmd/git-sv/main.go
+++ b/cmd/git-sv/main.go
@@ -121,6 +121,13 @@ When flag range is "date", if "end" is YYYY-MM-DD the range will be inclusive.`,
 				Flags:   commands.TagFlags(&gsv.Settings.TagSettings),
 			},
 			{
+				Name:    "retag",
+				Aliases: []string{"rt"},
+				Usage:   "move the most recent (or a specific) tag to HEAD and force-push it",
+				Action:  commands.RetagHandler(gsv, &gsv.Settings.RetagSettings),
+				Flags:   commands.RetagFlags(&gsv.Settings.RetagSettings),
+			},
+			{
 				Name:    "commit",
 				Aliases: []string{"cmt"},
 				Usage:   "execute git commit with conventional commit message helper",

--- a/cmd/git-sv/main.go
+++ b/cmd/git-sv/main.go
@@ -123,7 +123,7 @@ When flag range is "date", if "end" is YYYY-MM-DD the range will be inclusive.`,
 			{
 				Name:    "retag",
 				Aliases: []string{"rt"},
-				Usage:   "move the most recent (or a specific) tag to HEAD and force-push it",
+				Usage:   "move the most recently created (or a specific) tag to HEAD and force-push it",
 				Action:  commands.RetagHandler(gsv, &gsv.Settings.RetagSettings),
 				Flags:   commands.RetagFlags(&gsv.Settings.RetagSettings),
 			},


### PR DESCRIPTION
Add a `retag` sub-command (alias `rt`) that force-moves the most recent (or a specific `-t` tag) to HEAD and force-pushes it.

`tag --force` is effectively unusable for this because the tag handler always computes the next version, so it never re-tags the existing one. `retag` instead resolves the existing tag and reuses the current Tag() logic with force enabled.

Adjust/modify as needed.

Closes #306