### PR TITLE
fix: change `--force` flag to recreate current version tag

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -21,6 +21,7 @@ import (
 var (
 	ErrNoDataFound        = errors.New("no data found in repository")
 	ErrCommitMessageEmpty = errors.New("commit message is empty")
+	ErrNoExistingTag      = errors.New("no existing tag to recreate")
 )
 
 // Tag git tag info.
@@ -269,8 +270,7 @@ func (g GitSV) Tag(version semver.Version, annotate, local, force bool) (string,
 	}
 
 	if force {
-		err = repo.DeleteTag(tag)
-		if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
+		if err := repo.DeleteTag(tag); err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return tag, fmt.Errorf("failed to replace existing tag: %w", err)
 		}
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -25,10 +25,8 @@ type testRepo struct {
 func setupGitRepo(t *testing.T, tr testRepo) string {
 	t.Helper()
 
-	// Create a temporary directory using t.TempDir() which is automatically cleaned up
 	tmpDir := t.TempDir()
-
-	// Change to the temporary directory
+	t.Setenv("HOME", tmpDir)
 	t.Chdir(tmpDir)
 	// Initialize git repository
 	runGitCommand(t, "init", "-b", "main")

--- a/app/commands/tag.go
+++ b/app/commands/tag.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/rs/zerolog/log"
 	"github.com/thegeeklab/git-sv/app"
 	"github.com/thegeeklab/git-sv/sv"
@@ -26,7 +27,7 @@ func TagFlags(settings *app.TagSettings) []cli.Flag {
 		&cli.BoolFlag{
 			Name:        "force",
 			Aliases:     []string{"f"},
-			Usage:       "replace tag if it already exists",
+			Usage:       "recreate the current tag if it already exists",
 			Destination: &settings.Force,
 		},
 	}
@@ -41,6 +42,14 @@ func TagHandler(g app.GitSV, settings *app.TagSettings) cli.ActionFunc {
 			return fmt.Errorf("error parsing version: %s from git tag: %w", lastTag, err)
 		}
 
+		if settings.Force {
+			if lastTag == "" {
+				return app.ErrNoExistingTag
+			}
+
+			return createAndPrintTag(g, *currentVer, settings)
+		}
+
 		commits, err := g.Log(app.NewLogRange(app.TagRange, lastTag, ""))
 		if err != nil {
 			return fmt.Errorf("error getting git log: %w", err)
@@ -53,13 +62,17 @@ func TagHandler(g app.GitSV, settings *app.TagSettings) cli.ActionFunc {
 			return nil
 		}
 
-		tagname, err := g.Tag(*nextVer, settings.Annotate, settings.Local, settings.Force)
-		if err != nil {
-			return fmt.Errorf("error generating tag version: %s: %w", nextVer.String(), err)
-		}
-
-		fmt.Println(tagname)
-
-		return nil
+		return createAndPrintTag(g, *nextVer, settings)
 	}
+}
+
+func createAndPrintTag(g app.GitSV, version semver.Version, settings *app.TagSettings) error {
+	tagname, err := g.Tag(version, settings.Annotate, settings.Local, settings.Force)
+	if err != nil {
+		return fmt.Errorf("error generating tag version: %s: %w", version.String(), err)
+	}
+
+	fmt.Println(tagname)
+
+	return nil
 }

--- a/app/commands/tag_test.go
+++ b/app/commands/tag_test.go
@@ -1,20 +1,138 @@
 package commands
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thegeeklab/git-sv/app"
 )
+
+func setupTestRepo(t *testing.T) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	runGitCmd(t, "init", "-b", "main")
+	runGitCmd(t, "config", "user.email", "test@example.com")
+	runGitCmd(t, "config", "user.name", "Test")
+	runGitCmd(t, "config", "commit.gpgsign", "false")
+
+	testFile := filepath.Join(tmpDir, "test.txt")
+	err := os.WriteFile(testFile, []byte("initial"), 0o644)
+	require.NoError(t, err)
+
+	runGitCmd(t, "add", "test.txt")
+	runGitCmd(t, "commit", "-m", "feat: initial commit")
+	runGitCmd(t, "tag", "1.0.0")
+
+	err = os.WriteFile(testFile, []byte("updated"), 0o644)
+	require.NoError(t, err)
+
+	runGitCmd(t, "add", "test.txt")
+	runGitCmd(t, "commit", "-m", "feat: add feature")
+}
+
+func runGitCmd(t *testing.T, args ...string) {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, output)
+}
+
+func gitTags(t *testing.T) []string {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "git", "tag", "-l")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+
+	return strings.Fields(string(output))
+}
 
 func TestTagFlags(t *testing.T) {
 	flags := TagFlags(&app.TagSettings{})
 	assert.NotEmpty(t, flags)
 }
 
-func TestTagHandler(t *testing.T) {
+func TestTagHandlerCreatesNextVersion(t *testing.T) {
+	setupTestRepo(t)
+
 	gsv := app.New()
-	settings := &app.TagSettings{}
+	settings := &app.TagSettings{
+		Force: false,
+		Local: true,
+	}
+
 	handler := TagHandler(gsv, settings)
-	assert.NotNil(t, handler)
+	err := handler(context.Background(), nil)
+
+	assert.NoError(t, err)
+
+	tags := gitTags(t)
+	assert.Contains(t, tags, "1.1.0", "without --force, the next version 1.1.0 should be created")
+}
+
+func TestTagHandlerForceRecreatesCurrentTag(t *testing.T) {
+	setupTestRepo(t)
+
+	gsv := app.New()
+	settings := &app.TagSettings{
+		Force: true,
+		Local: true,
+	}
+
+	handler := TagHandler(gsv, settings)
+	err := handler(context.Background(), nil)
+
+	assert.NoError(t, err)
+
+	tags := gitTags(t)
+	assert.Contains(t, tags, "1.0.0", "with --force, the current tag 1.0.0 should still exist")
+	assert.NotContains(t, tags, "1.1.0", "with --force, the next version 1.1.0 should NOT be created")
+}
+
+func TestTagHandlerNoNewCommitsNothingToDo(t *testing.T) {
+	setupTestRepo(t)
+
+	runGitCmd(t, "tag", "1.1.0")
+
+	gsv := app.New()
+	settings := &app.TagSettings{
+		Force: false,
+		Local: true,
+	}
+
+	handler := TagHandler(gsv, settings)
+	err := handler(context.Background(), nil)
+
+	assert.NoError(t, err)
+
+	tags := gitTags(t)
+	assert.Len(t, tags, 2, "no new commits means no new tag should be created")
+}
+
+func TestTagHandlerForceNoTagExists(t *testing.T) {
+	setupTestRepo(t)
+
+	runGitCmd(t, "tag", "-d", "1.0.0")
+
+	gsv := app.New()
+	settings := &app.TagSettings{
+		Force: true,
+		Local: true,
+	}
+
+	handler := TagHandler(gsv, settings)
+	err := handler(context.Background(), nil)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no existing tag to recreate")
 }


### PR DESCRIPTION
The `tag --force` flag now triggers an early return that explicitly recreates the most recent tag, skipping the commit log analysis and version bumping entirely.