### PR TITLE
refactor: drop `--force` flag from `tag` command

### DIFF
--- a/app/commands/tag.go
+++ b/app/commands/tag.go
@@ -23,12 +23,6 @@ func TagFlags(settings *app.TagSettings) []cli.Flag {
 			Usage:       "create local tag only",
 			Destination: &settings.Local,
 		},
-		&cli.BoolFlag{
-			Name:        "force",
-			Aliases:     []string{"f"},
-			Usage:       "replace tag if it already exists",
-			Destination: &settings.Force,
-		},
 	}
 }
 
@@ -53,7 +47,7 @@ func TagHandler(g app.GitSV, settings *app.TagSettings) cli.ActionFunc {
 			return nil
 		}
 
-		tagname, err := g.Tag(*nextVer, settings.Annotate, settings.Local, settings.Force)
+		tagname, err := g.Tag(*nextVer, settings.Annotate, settings.Local, false)
 		if err != nil {
 			return fmt.Errorf("error generating tag version: %s: %w", nextVer.String(), err)
 		}

--- a/app/config.go
+++ b/app/config.go
@@ -52,7 +52,6 @@ type CommitLogSettings struct {
 type TagSettings struct {
 	Annotate bool
 	Local    bool
-	Force    bool
 }
 
 // Config cli yaml config.


### PR DESCRIPTION
The `--force`/`-f` flag on `git sv tag` is effectively useless: the tag handler always computes the next version, so it never re-tags an existing one and force has no effect.

Refs #306