### PR TITLE
feat: add `retag` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ COMMANDS:
    release-notes, rn             generate release notes
    changelog, cgl                generate changelog
    tag, tg                       generate tag with version based on git commit messages
+   retag, rt                     move the most recent (or a specific) tag to HEAD and force-push it
    commit, cmt                   execute git commit with conventional commit message helper
    validate-commit-message, vcm  use as prepare-commit-message hook to validate and enhance commit message
    help, h                       Shows a list of commands or help for one command

--- a/app/app.go
+++ b/app/app.go
@@ -25,8 +25,9 @@ var (
 
 // Tag git tag info.
 type Tag struct {
-	Name string
-	Date time.Time
+	Name      string
+	Date      time.Time
+	Annotated bool
 }
 
 // LogRangeType type of log range.
@@ -336,7 +337,9 @@ func (g GitSV) Tags() ([]Tag, error) {
 
 		// Try to get annotated tag first
 		tagObj, err := repo.TagObject(ref.Hash())
-		if err == nil {
+
+		annotated := err == nil
+		if annotated {
 			tagDate = tagObj.Tagger.When
 		} else {
 			// For lightweight tags, get the commit
@@ -348,8 +351,9 @@ func (g GitSV) Tags() ([]Tag, error) {
 		}
 
 		tags = append(tags, Tag{
-			Name: tagName,
-			Date: tagDate,
+			Name:      tagName,
+			Date:      tagDate,
+			Annotated: annotated,
 		})
 
 		return nil

--- a/app/app.go
+++ b/app/app.go
@@ -271,7 +271,6 @@ func (g GitSV) Tag(version semver.Version, annotate, local bool) (string, error)
 
 	var tagOpts *git.CreateTagOptions
 	if annotate {
-		// Create an annotated tag with a message
 		tagOpts = &git.CreateTagOptions{
 			Message: tagMsg,
 		}
@@ -368,6 +367,82 @@ func (g GitSV) Tags() ([]Tag, error) {
 	})
 
 	return tags, nil
+}
+
+// Retag moves the existing tag with the given name to HEAD. The exact name
+// is preserved (no pattern reformatting). If the tag already points to HEAD,
+// the local rewrite is skipped; a force-push is still issued when !local so
+// a stale remote ref is reconciled.
+func (g GitSV) Retag(existingName string, annotate, local bool) (string, error) {
+	repo, err := git.PlainOpen(".")
+	if err != nil {
+		return existingName, fmt.Errorf("failed to open git repository: %w", err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return existingName, fmt.Errorf("failed to get HEAD reference: %w", err)
+	}
+
+	tagCommit, err := resolveTagCommit(repo, existingName)
+	if err != nil {
+		return existingName, fmt.Errorf("failed to resolve tag %q: %w", existingName, err)
+	}
+
+	if tagCommit != head.Hash() {
+		tagMsg := fmt.Sprintf("Version %s", existingName)
+
+		var tagOpts *git.CreateTagOptions
+		if annotate {
+			tagOpts = &git.CreateTagOptions{Message: tagMsg}
+		}
+
+		if delErr := repo.DeleteTag(existingName); delErr != nil && !errors.Is(delErr, git.ErrTagNotFound) {
+			return existingName, fmt.Errorf("failed to delete existing tag: %w", delErr)
+		}
+
+		if _, err = repo.CreateTag(existingName, head.Hash(), tagOpts); err != nil {
+			return existingName, fmt.Errorf("failed to create tag: %w", err)
+		}
+	}
+
+	if local {
+		return existingName, nil
+	}
+
+	remote, err := repo.Remote("origin")
+	if err != nil {
+		return existingName, fmt.Errorf("failed to get remote: %w", err)
+	}
+
+	refSpec := fmt.Sprintf("refs/tags/%s:refs/tags/%s", existingName, existingName)
+
+	if err = remote.Push(&git.PushOptions{
+		RefSpecs: []config.RefSpec{config.RefSpec(refSpec)},
+		Force:    true,
+	}); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+		return existingName, fmt.Errorf("failed to push tag: %w", err)
+	}
+
+	return existingName, nil
+}
+
+// resolveTagCommit returns the commit hash the named tag points to,
+// handling both annotated and lightweight tags.
+func resolveTagCommit(repo *git.Repository, name string) (plumbing.Hash, error) {
+	ref, err := repo.Reference(plumbing.ReferenceName("refs/tags/"+name), false)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	if ref == nil {
+		return plumbing.ZeroHash, plumbing.ErrReferenceNotFound
+	}
+
+	if tagObj, terr := repo.TagObject(ref.Hash()); terr == nil {
+		return tagObj.Target, nil
+	}
+
+	return ref.Hash(), nil
 }
 
 // Branch get git branch.

--- a/app/app.go
+++ b/app/app.go
@@ -370,9 +370,8 @@ func (g GitSV) Tags() ([]Tag, error) {
 }
 
 // Retag moves the existing tag with the given name to HEAD. The exact name
-// is preserved (no pattern reformatting). If the tag already points to HEAD,
-// the local rewrite is skipped; a force-push is still issued when !local so
-// a stale remote ref is reconciled.
+// is preserved (no pattern reformatting). If the tag already points to HEAD
+// and no annotation upgrade is required, the local rewrite is skipped.
 func (g GitSV) Retag(existingName string, annotate, local bool) (string, error) {
 	repo, err := git.PlainOpen(".")
 	if err != nil {
@@ -384,12 +383,12 @@ func (g GitSV) Retag(existingName string, annotate, local bool) (string, error) 
 		return existingName, fmt.Errorf("failed to get HEAD reference: %w", err)
 	}
 
-	tagCommit, err := resolveTagCommit(repo, existingName)
+	tagCommit, existingAnnotated, err := resolveTagCommit(repo, existingName)
 	if err != nil {
 		return existingName, fmt.Errorf("failed to resolve tag %q: %w", existingName, err)
 	}
 
-	if tagCommit != head.Hash() {
+	if tagCommit != head.Hash() || (annotate && !existingAnnotated) {
 		tagMsg := fmt.Sprintf("Version %s", existingName)
 
 		var tagOpts *git.CreateTagOptions
@@ -427,22 +426,24 @@ func (g GitSV) Retag(existingName string, annotate, local bool) (string, error) 
 	return existingName, nil
 }
 
-// resolveTagCommit returns the commit hash the named tag points to,
-// handling both annotated and lightweight tags.
-func resolveTagCommit(repo *git.Repository, name string) (plumbing.Hash, error) {
+// resolveTagCommit returns the commit hash the named tag points to and
+// whether the tag is annotated, handling both annotated and lightweight
+// tags.
+func resolveTagCommit(repo *git.Repository, name string) (plumbing.Hash, bool, error) {
 	ref, err := repo.Reference(plumbing.ReferenceName("refs/tags/"+name), false)
 	if err != nil {
-		return plumbing.ZeroHash, err
+		return plumbing.ZeroHash, false, err
 	}
+
 	if ref == nil {
-		return plumbing.ZeroHash, plumbing.ErrReferenceNotFound
+		return plumbing.ZeroHash, false, plumbing.ErrReferenceNotFound
 	}
 
 	if tagObj, terr := repo.TagObject(ref.Hash()); terr == nil {
-		return tagObj.Target, nil
+		return tagObj.Target, true, nil
 	}
 
-	return ref.Hash(), nil
+	return ref.Hash(), false, nil
 }
 
 // Branch get git branch.

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -25,6 +25,8 @@ type testRepo struct {
 func setupGitRepo(t *testing.T, tr testRepo) string {
 	t.Helper()
 
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+
 	// Create a temporary directory using t.TempDir() which is automatically cleaned up
 	tmpDir := t.TempDir()
 

--- a/app/commands/retag.go
+++ b/app/commands/retag.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/thegeeklab/git-sv/app"
+	"github.com/thegeeklab/git-sv/sv"
+	"github.com/urfave/cli/v3"
+)
+
+var errNoTagToRetag = errors.New("no tag found to retag")
+
+func RetagFlags(settings *app.RetagSettings) []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "annotate",
+			Aliases:     []string{"a"},
+			Usage:       "make an annotated tag object",
+			Destination: &settings.Annotate,
+		},
+		&cli.BoolFlag{
+			Name:        "local",
+			Usage:       "retag local tag only",
+			Destination: &settings.Local,
+		},
+		&cli.StringFlag{
+			Name:        "tag",
+			Aliases:     []string{"t"},
+			Usage:       "retag a specific tag instead of the most recent one",
+			Destination: &settings.Tag,
+		},
+	}
+}
+
+func RetagHandler(g app.GitSV, settings *app.RetagSettings) cli.ActionFunc {
+	return func(_ context.Context, _ *cli.Command) error {
+		target := settings.Tag
+		if target == "" {
+			target = g.LastTag()
+		}
+
+		if target == "" {
+			return errNoTagToRetag
+		}
+
+		version, err := sv.ToVersion(target)
+		if err != nil {
+			return fmt.Errorf("error parsing version: %s from git tag: %w", target, err)
+		}
+
+		tagname, err := g.Tag(*version, settings.Annotate, settings.Local, true)
+		if err != nil {
+			return fmt.Errorf("error retagging version: %s: %w", version.String(), err)
+		}
+
+		fmt.Println(tagname)
+
+		return nil
+	}
+}

--- a/app/commands/retag.go
+++ b/app/commands/retag.go
@@ -4,20 +4,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/thegeeklab/git-sv/app"
 	"github.com/thegeeklab/git-sv/sv"
 	"github.com/urfave/cli/v3"
 )
 
-var errNoTagToRetag = errors.New("no tag found to retag")
+var (
+	errNoTagToRetag = errors.New("no tag found to retag")
+	errTagNotFound  = errors.New("tag not found")
+)
 
 func RetagFlags(settings *app.RetagSettings) []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{
 			Name:        "annotate",
 			Aliases:     []string{"a"},
-			Usage:       "make an annotated tag object",
+			Usage:       "force an annotated tag object (annotated source tags are preserved regardless)",
 			Destination: &settings.Annotate,
 		},
 		&cli.BoolFlag{
@@ -28,7 +32,7 @@ func RetagFlags(settings *app.RetagSettings) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "tag",
 			Aliases:     []string{"t"},
-			Usage:       "retag a specific tag instead of the most recent one",
+			Usage:       "retag a specific existing tag instead of the most recently created one",
 			Destination: &settings.Tag,
 		},
 	}
@@ -36,21 +40,40 @@ func RetagFlags(settings *app.RetagSettings) []cli.Flag {
 
 func RetagHandler(g app.GitSV, settings *app.RetagSettings) cli.ActionFunc {
 	return func(_ context.Context, _ *cli.Command) error {
-		target := settings.Tag
-		if target == "" {
-			target = g.LastTag()
-		}
-
-		if target == "" {
-			return errNoTagToRetag
-		}
-
-		version, err := sv.ToVersion(target)
+		tags, err := g.Tags()
 		if err != nil {
-			return fmt.Errorf("error parsing version: %s from git tag: %w", target, err)
+			return fmt.Errorf("error listing tags: %w", err)
 		}
 
-		tagname, err := g.Tag(*version, settings.Annotate, settings.Local, true)
+		var target app.Tag
+
+		if settings.Tag != "" {
+			idx := slices.IndexFunc(tags, func(t app.Tag) bool { return t.Name == settings.Tag })
+			if idx < 0 {
+				return fmt.Errorf("%w: %s", errTagNotFound, settings.Tag)
+			}
+
+			target = tags[idx]
+		} else {
+			if len(tags) == 0 {
+				return errNoTagToRetag
+			}
+
+			// Tags() is sorted by date (oldest first), so the most recently
+			// created tag is the last entry.
+			target = tags[len(tags)-1]
+		}
+
+		version, err := sv.ToVersion(target.Name)
+		if err != nil {
+			return fmt.Errorf("error parsing version: %s from git tag: %w", target.Name, err)
+		}
+
+		// Preserve the original tag type: never silently downgrade an annotated
+		// tag to a lightweight one.
+		annotate := settings.Annotate || target.Annotated
+
+		tagname, err := g.Tag(*version, annotate, settings.Local, true)
 		if err != nil {
 			return fmt.Errorf("error retagging version: %s: %w", version.String(), err)
 		}

--- a/app/commands/retag.go
+++ b/app/commands/retag.go
@@ -64,8 +64,7 @@ func RetagHandler(g app.GitSV, settings *app.RetagSettings) cli.ActionFunc {
 			target = tags[len(tags)-1]
 		}
 
-		version, err := sv.ToVersion(target.Name)
-		if err != nil {
+		if _, err := sv.ToVersion(target.Name); err != nil {
 			return fmt.Errorf("error parsing version: %s from git tag: %w", target.Name, err)
 		}
 
@@ -73,9 +72,9 @@ func RetagHandler(g app.GitSV, settings *app.RetagSettings) cli.ActionFunc {
 		// tag to a lightweight one.
 		annotate := settings.Annotate || target.Annotated
 
-		tagname, err := g.Tag(*version, annotate, settings.Local, true)
+		tagname, err := g.Retag(target.Name, annotate, settings.Local)
 		if err != nil {
-			return fmt.Errorf("error retagging version: %s: %w", version.String(), err)
+			return fmt.Errorf("error retagging %s: %w", target.Name, err)
 		}
 
 		fmt.Println(tagname)

--- a/app/commands/retag_test.go
+++ b/app/commands/retag_test.go
@@ -1,0 +1,20 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thegeeklab/git-sv/app"
+)
+
+func TestRetagFlags(t *testing.T) {
+	flags := RetagFlags(&app.RetagSettings{})
+	assert.NotEmpty(t, flags)
+}
+
+func TestRetagHandler(t *testing.T) {
+	gsv := app.New()
+	settings := &app.RetagSettings{}
+	handler := RetagHandler(gsv, settings)
+	assert.NotNil(t, handler)
+}

--- a/app/commands/retag_test.go
+++ b/app/commands/retag_test.go
@@ -36,6 +36,8 @@ func runGit(t *testing.T, env []string, args ...string) string {
 func setupRetagRepo(t *testing.T) string {
 	t.Helper()
 
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+
 	dir := t.TempDir()
 	t.Chdir(dir)
 
@@ -142,4 +144,53 @@ func TestRetagHandlerPreservesAnnotatedType(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "tag", runGit(t, nil, "cat-file", "-t", "1.0.0"))
+}
+
+func TestRetagHandlerPreservesVPrefix(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "v1.0.0")
+
+	head := commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+
+	err := runRetag(t, &app.RetagSettings{Local: true, Tag: "v1.0.0"})
+	require.NoError(t, err)
+
+	// The v-prefixed tag must move to HEAD, and the default-pattern tag must
+	// not be silently created.
+	assert.Equal(t, head, runGit(t, nil, "rev-parse", "v1.0.0"))
+	assert.Equal(t, "v1.0.0", runGit(t, nil, "tag", "--list"))
+}
+
+func TestRetagHandlerPreservesPrerelease(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "1.0.0-rc1")
+
+	head := commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+
+	err := runRetag(t, &app.RetagSettings{Local: true, Tag: "1.0.0-rc1"})
+	require.NoError(t, err)
+
+	// The pre-release suffix must be preserved; no "1.0.0" tag must be created.
+	assert.Equal(t, head, runGit(t, nil, "rev-parse", "1.0.0-rc1"))
+	assert.Equal(t, "1.0.0-rc1", runGit(t, nil, "tag", "--list"))
+}
+
+func TestRetagHandlerNoopWhenTagAtHead(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+
+	env := []string{"GIT_COMMITTER_DATE=2020-01-01T00:00:00", "GIT_AUTHOR_DATE=2020-01-01T00:00:00"}
+	runGit(t, env, "tag", "-a", "-m", "release", "1.0.0")
+
+	// Capture the annotated tag object identity; if the handler deletes and
+	// recreates it, the tag object hash will change.
+	originalTagObj := runGit(t, nil, "rev-parse", "1.0.0^{tag}")
+
+	err := runRetag(t, &app.RetagSettings{Local: true})
+	require.NoError(t, err)
+
+	// No-op: the underlying tag object must be untouched.
+	assert.Equal(t, originalTagObj, runGit(t, nil, "rev-parse", "1.0.0^{tag}"))
 }

--- a/app/commands/retag_test.go
+++ b/app/commands/retag_test.go
@@ -72,6 +72,18 @@ func runRetag(t *testing.T, settings *app.RetagSettings) error {
 	return RetagHandler(gsv, settings)(context.Background(), nil)
 }
 
+// setupRemote initializes a bare git repository in a temp dir, adds it as
+// `origin` to the current test repo and returns the bare repo path.
+func setupRemote(t *testing.T) string {
+	t.Helper()
+
+	remoteDir := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, nil, "init", "--bare", remoteDir)
+	runGit(t, nil, "remote", "add", "origin", remoteDir)
+
+	return remoteDir
+}
+
 func TestRetagFlags(t *testing.T) {
 	flags := RetagFlags(&app.RetagSettings{})
 	assert.NotEmpty(t, flags)
@@ -193,4 +205,85 @@ func TestRetagHandlerNoopWhenTagAtHead(t *testing.T) {
 
 	// No-op: the underlying tag object must be untouched.
 	assert.Equal(t, originalTagObj, runGit(t, nil, "rev-parse", "1.0.0^{tag}"))
+}
+
+func TestRetagHandlerPushesToRemote(t *testing.T) {
+	dir := setupRetagRepo(t)
+	remoteDir := setupRemote(t)
+
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "1.0.0")
+	head := commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+
+	require.NoError(t, runRetag(t, &app.RetagSettings{}))
+
+	remoteCommit := runGit(t, []string{"GIT_DIR=" + remoteDir}, "rev-parse", "1.0.0^{commit}")
+	assert.Equal(t, head, remoteCommit)
+}
+
+func TestRetagHandlerReconcilesStaleRemote(t *testing.T) {
+	dir := setupRetagRepo(t)
+	remoteDir := setupRemote(t)
+
+	oldHead := commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "1.0.0")
+	runGit(t, nil, "push", "origin", "1.0.0")
+
+	// Confirm the remote is stale before retag runs.
+	assert.Equal(t, oldHead, runGit(t, []string{"GIT_DIR=" + remoteDir}, "rev-parse", "1.0.0^{commit}"))
+
+	newHead := commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+	runGit(t, nil, "tag", "-f", "1.0.0", newHead)
+
+	require.NoError(t, runRetag(t, &app.RetagSettings{}))
+
+	remoteCommit := runGit(t, []string{"GIT_DIR=" + remoteDir}, "rev-parse", "1.0.0^{commit}")
+	assert.Equal(t, newHead, remoteCommit)
+}
+
+func TestRetagHandlerNoRemote(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "1.0.0")
+	commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+
+	err := runRetag(t, &app.RetagSettings{})
+	require.Error(t, err)
+}
+
+func TestRetagHandlerNonSemverTag(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "release-2024")
+	head := commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+
+	err := runRetag(t, &app.RetagSettings{Local: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "release-2024")
+
+	// The non-semver tag must not be moved to HEAD.
+	assert.NotEqual(t, head, runGit(t, nil, "rev-parse", "release-2024"))
+}
+
+func TestRetagHandlerUpgradesLightweightToAnnotated(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "1.0.0")
+	commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+
+	require.NoError(t, runRetag(t, &app.RetagSettings{Local: true, Annotate: true}))
+
+	assert.Equal(t, "tag", runGit(t, nil, "cat-file", "-t", "1.0.0"))
+}
+
+func TestRetagHandlerUpgradesLightweightToAnnotatedAtHead(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "1.0.0")
+
+	// The tag is already at HEAD. The -a flag must still upgrade the
+	// lightweight tag to annotated rather than silently no-op.
+	require.NoError(t, runRetag(t, &app.RetagSettings{Local: true, Annotate: true}))
+
+	assert.Equal(t, "tag", runGit(t, nil, "cat-file", "-t", "1.0.0"))
 }

--- a/app/commands/retag_test.go
+++ b/app/commands/retag_test.go
@@ -1,11 +1,74 @@
 package commands
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thegeeklab/git-sv/app"
 )
+
+// runGit runs a git command inside the current working directory and returns
+// its trimmed combined output.
+func runGit(t *testing.T, env []string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	if env != nil {
+		cmd.Env = append(os.Environ(), env...)
+	}
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+// setupRetagRepo initializes an empty git repository in a temp dir, chdirs into
+// it and returns the path.
+func setupRetagRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	runGit(t, nil, "init", "-b", "main")
+	runGit(t, nil, "config", "user.email", "test@example.com")
+	runGit(t, nil, "config", "user.name", "Test User")
+	runGit(t, nil, "config", "commit.gpgsign", "false")
+	runGit(t, nil, "config", "tag.gpgSign", "false")
+
+	return dir
+}
+
+// commit creates a file, commits it with a fixed author/committer date and
+// returns the resulting commit hash.
+func commit(t *testing.T, dir, name, date string) string {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(name), 0o644))
+	runGit(t, nil, "add", ".")
+
+	env := []string{"GIT_AUTHOR_DATE=" + date, "GIT_COMMITTER_DATE=" + date}
+	runGit(t, env, "commit", "-m", "chore: add "+name)
+
+	return runGit(t, nil, "rev-parse", "HEAD")
+}
+
+func runRetag(t *testing.T, settings *app.RetagSettings) error {
+	t.Helper()
+
+	gsv := app.New()
+
+	return RetagHandler(gsv, settings)(context.Background(), nil)
+}
 
 func TestRetagFlags(t *testing.T) {
 	flags := RetagFlags(&app.RetagSettings{})
@@ -17,4 +80,66 @@ func TestRetagHandler(t *testing.T) {
 	settings := &app.RetagSettings{}
 	handler := RetagHandler(gsv, settings)
 	assert.NotNil(t, handler)
+}
+
+func TestRetagHandlerNoTags(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+
+	err := runRetag(t, &app.RetagSettings{Local: true})
+	assert.ErrorIs(t, err, errNoTagToRetag)
+}
+
+func TestRetagHandlerSpecificTagNotFound(t *testing.T) {
+	dir := setupRetagRepo(t)
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "1.0.0")
+
+	err := runRetag(t, &app.RetagSettings{Local: true, Tag: "9.9.9"})
+
+	// A specific tag that does not exist must fail instead of silently
+	// creating a fresh tag at HEAD.
+	assert.ErrorIs(t, err, errTagNotFound)
+
+	tags := runGit(t, nil, "tag", "--list")
+	assert.NotContains(t, tags, "9.9.9")
+}
+
+func TestRetagHandlerMostRecentByDate(t *testing.T) {
+	dir := setupRetagRepo(t)
+
+	// Highest semver tag is created on the oldest commit, while a lower version
+	// is tagged more recently (e.g. a backport).
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+	runGit(t, nil, "tag", "2.0.0")
+
+	commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+	runGit(t, nil, "tag", "1.5.0")
+
+	head := commit(t, dir, "c.txt", "2022-01-01T00:00:00")
+
+	err := runRetag(t, &app.RetagSettings{Local: true})
+	require.NoError(t, err)
+
+	// The chronologically newest tag (1.5.0) is moved to HEAD, the higher
+	// semver tag (2.0.0) is left untouched.
+	assert.Equal(t, head, runGit(t, nil, "rev-parse", "1.5.0"))
+	assert.NotEqual(t, head, runGit(t, nil, "rev-parse", "2.0.0"))
+}
+
+func TestRetagHandlerPreservesAnnotatedType(t *testing.T) {
+	dir := setupRetagRepo(t)
+
+	commit(t, dir, "a.txt", "2020-01-01T00:00:00")
+
+	env := []string{"GIT_COMMITTER_DATE=2020-01-01T00:00:00", "GIT_AUTHOR_DATE=2020-01-01T00:00:00"}
+	runGit(t, env, "tag", "-a", "-m", "release 1.0.0", "1.0.0")
+
+	commit(t, dir, "b.txt", "2021-01-01T00:00:00")
+
+	// Retag without -a must not downgrade the annotated tag to a lightweight one.
+	err := runRetag(t, &app.RetagSettings{Local: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, "tag", runGit(t, nil, "cat-file", "-t", "1.0.0"))
 }

--- a/app/config.go
+++ b/app/config.go
@@ -20,6 +20,7 @@ type Settings struct {
 	CommitNotesSettings  CommitNotesSettings
 	CommitLogSettings    CommitLogSettings
 	TagSettings          TagSettings
+	RetagSettings        RetagSettings
 }
 
 type ChangelogSettings struct {
@@ -52,6 +53,12 @@ type CommitLogSettings struct {
 type TagSettings struct {
 	Annotate bool
 	Local    bool
+}
+
+type RetagSettings struct {
+	Annotate bool
+	Local    bool
+	Tag      string
 }
 
 // Config cli yaml config.

--- a/cmd/git-sv/main.go
+++ b/cmd/git-sv/main.go
@@ -121,6 +121,13 @@ When flag range is "date", if "end" is YYYY-MM-DD the range will be inclusive.`,
 				Flags:   commands.TagFlags(&gsv.Settings.TagSettings),
 			},
 			{
+				Name:    "retag",
+				Aliases: []string{"rt"},
+				Usage:   "move the most recent (or a specific) tag to HEAD and force-push it",
+				Action:  commands.RetagHandler(gsv, &gsv.Settings.RetagSettings),
+				Flags:   commands.RetagFlags(&gsv.Settings.RetagSettings),
+			},
+			{
 				Name:    "commit",
 				Aliases: []string{"cmt"},
 				Usage:   "execute git commit with conventional commit message helper",

--- a/cmd/git-sv/main.go
+++ b/cmd/git-sv/main.go
@@ -123,7 +123,7 @@ When flag range is "date", if "end" is YYYY-MM-DD the range will be inclusive.`,
 			{
 				Name:    "retag",
 				Aliases: []string{"rt"},
-				Usage:   "move the most recent (or a specific) tag to HEAD and force-push it",
+				Usage:   "move the most recently created (or a specific) tag to HEAD and force-push it",
 				Action:  commands.RetagHandler(gsv, &gsv.Settings.RetagSettings),
 				Flags:   commands.RetagFlags(&gsv.Settings.RetagSettings),
 			},

--- a/sv/commit_test.go
+++ b/sv/commit_test.go
@@ -115,7 +115,8 @@ func TestSemVerCommitProcessor_NextVersion(t *testing.T) {
 					UpdatePatch:   []string{"patch"},
 					IgnoreUnknown: tt.ignoreUnknown,
 				},
-				CommitMessageConfig{Types: []string{"major", "minor", "patch", "none"}})
+				CommitMessageConfig{Types: []string{"major", "minor", "patch", "none"}},
+			)
 			got, gotUpdated := p.NextVersion(tt.version, tt.commits)
 
 			assert.Equal(t, tt.want, got)

--- a/sv/formatter/formatter_test.go
+++ b/sv/formatter/formatter_test.go
@@ -166,15 +166,18 @@ func releaseNotesVariables(release string) releaseNoteTemplateVariables {
 		Release: release,
 		Date:    time.Date(2006, 1, 0o2, 0, 0, 0, 0, time.UTC),
 		Sections: []sv.ReleaseNoteSection{
-			sv.TestNewReleaseNoteCommitsSection("Features",
+			sv.TestNewReleaseNoteCommitsSection(
+				"Features",
 				[]string{"feat"},
 				[]sv.CommitLog{sv.TestCommitlog("feat", map[string]string{}, "a")},
 			),
-			sv.TestNewReleaseNoteCommitsSection("Bug Fixes",
+			sv.TestNewReleaseNoteCommitsSection(
+				"Bug Fixes",
 				[]string{"fix"},
 				[]sv.CommitLog{sv.TestCommitlog("fix", map[string]string{}, "a")},
 			),
-			sv.TestNewReleaseNoteCommitsSection("Build",
+			sv.TestNewReleaseNoteCommitsSection(
+				"Build",
 				[]string{"build"},
 				[]sv.CommitLog{sv.TestCommitlog("build", map[string]string{}, "a")},
 			),

--- a/sv/releasenotes_test.go
+++ b/sv/releasenotes_test.go
@@ -114,7 +114,8 @@ func TestReleaseNoteProcessorImpl_Create(t *testing.T) {
 						{Name: "Tag 2", SectionType: "commits", CommitTypes: []string{"t2"}},
 						{Name: "Breaking Changes", SectionType: "breaking-changes"},
 					},
-				})
+				},
+			)
 			got := p.Create(tt.version, tt.tag, tt.date, tt.commits)
 
 			assert.Equal(t, tt.want, got)


### PR DESCRIPTION
Supersedes: https://github.com/thegeeklab/git-sv/pull/327

Additional changes:

`Tag()` creates a tag from a semver by reformatting through `Config.Tag.Pattern`. This drops the `v` prefix and pre-release/build metadata. For tag (compute next version → X.Y.Z) that's correct; for retag (move an existing tag) it means retag `--tag v1.0.0-rc1` would silently delete+force-push `1.0.0` instead, leaving the original untouched.

`Retag()` takes the exact tag name and uses it verbatim for delete, create, and push without pattern reformatting. It also unconditionally force-deletes and force-pushes, while `Tag()` never overwrites.